### PR TITLE
Extend AIS data with vessel type

### DIFF
--- a/backend/app/crud.py
+++ b/backend/app/crud.py
@@ -8,6 +8,7 @@ def get_ais(db: Session, mmsi: str | None = None):
     q = (
         db.query(
             Vessel.mmsi,
+            Vessel.type.label("ship_type"),
             AISData.timestamp,
             ST_Y(AISData.geom).label("latitude"),
             ST_X(AISData.geom).label("longitude"),
@@ -46,6 +47,7 @@ def get_latest_ais_in_bbox(
     q = (
         db.query(
             Vessel.mmsi,
+            Vessel.type.label("ship_type"),
             AISData.timestamp,
             ST_Y(AISData.geom).label("latitude"),
             ST_X(AISData.geom).label("longitude"),

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -11,6 +11,7 @@ class Vessel(Base):
     name        = Column(String, nullable=True)
     imo         = Column(String, nullable=True)
     destination = Column(String, nullable=True)
+    type        = Column(Integer, nullable=True)
     ais_points  = relationship("AISData", back_populates="vessel")
 
 class AISData(Base):

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -10,6 +10,7 @@ class AISDataOut(BaseModel):
     sog: Optional[float]
     cog: Optional[float]
     heading: Optional[float]
+    ship_type: Optional[int]
 
     class Config:
         from_attributes = True

--- a/frontend/src/shared/hooks/use-AIS-socket.ts
+++ b/frontend/src/shared/hooks/use-AIS-socket.ts
@@ -9,6 +9,7 @@ export interface AISPoint {
   sog?: number;
   cog?: number;
   heading?: number;
+  ship_type?: number;
 }
 
 export function useAISSocket() {


### PR DESCRIPTION
## Summary
- store vessel type in DB
- include vessel type in AIS API responses
- persist ship type when ingesting AIS data
- expose ship type through WebSocket hook
- subscribe to ShipStaticData messages and update vessel type

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6840b1e18634833092bc8b0485e0e3bd